### PR TITLE
Add dashboard, triangles, and about routes

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,9 @@
-import { type RouteConfig, index } from '@react-router/dev/routes';
+import { type RouteConfig, index, route } from '@react-router/dev/routes';
 
-export default [index('routes/home.tsx')] satisfies RouteConfig;
+export default [
+  route('', 'routes/_layout.tsx', [
+    index('routes/_layout._index.tsx'),
+    route('triangles', 'routes/_layout.triangles.tsx'),
+    route('about', 'routes/_layout.about.tsx'),
+  ]),
+] satisfies RouteConfig;

--- a/app/routes/_layout._index.tsx
+++ b/app/routes/_layout._index.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router';
+import { PageHeader } from 'antd';
+
+export const meta = () => [{ title: 'Dashboard' }];
+
+export default function Dashboard() {
+  return (
+    <div className="p-4">
+      <PageHeader
+        title="Dashboard"
+        breadcrumb={{ items: [{ title: 'Dashboard' }] }}
+      />
+      <ul className="mt-4 list-disc list-inside">
+        <li>
+          <Link to="triangles">Triangles</Link>
+        </li>
+        <li>
+          <Link to="about">About</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/app/routes/_layout.about.tsx
+++ b/app/routes/_layout.about.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router';
+import { PageHeader } from 'antd';
+
+export const meta = () => [{ title: 'About' }];
+
+export default function About() {
+  return (
+    <div className="p-4">
+      <PageHeader
+        title="About"
+        breadcrumb={{
+          items: [{ title: <Link to="/">Dashboard</Link> }, { title: 'About' }],
+        }}
+      />
+      <p className="mt-4">This app explores React Remix with Ant Design.</p>
+    </div>
+  );
+}

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router';
+import { PageHeader } from 'antd';
+
+export const meta = () => [{ title: 'Triangles' }];
+
+export default function Triangles() {
+  return (
+    <div className="p-4">
+      <PageHeader
+        title="Triangles"
+        breadcrumb={{
+          items: [
+            { title: <Link to="/">Dashboard</Link> },
+            { title: 'Triangles' },
+          ],
+        }}
+      />
+      <p className="mt-4">This page is about triangles.</p>
+    </div>
+  );
+}

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from 'react-router';
+
+export default function Layout() {
+  return <Outlet />;
+}


### PR DESCRIPTION
## Summary
- add layout route with dashboard index and quick links
- create triangles and about pages with breadcrumb headers
- wire new routes into route configuration

## Testing
- `npm test -- --run` *(fails: React Router Vite plugin can't detect preamble)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab7f693ad0833089454136b5d86e5e