### PR TITLE
feat: dummy triangles data and loader

### DIFF
--- a/app/data/triangles.ts
+++ b/app/data/triangles.ts
@@ -1,0 +1,50 @@
+export type TriangleRow = {
+  portfolio: string;
+  lob: string;
+  accidentYear: number;
+  /** development lag in months */
+  dev: number;
+  paid: number;
+  incurred: number;
+};
+
+export function getTriangles(): TriangleRow[] {
+  const portfolios = ['Alpha', 'Beta'];
+  const lobs = ['Auto', 'Property'];
+  const accidentYears = [2018, 2019, 2020, 2021, 2022];
+  const devMap: Record<string, number[]> = {
+    'Alpha-Auto': [12, 24],
+    'Alpha-Property': [36, 48],
+    'Beta-Auto': [60, 12],
+    'Beta-Property': [24, 36],
+  };
+
+  const rows: TriangleRow[] = [];
+
+  for (const portfolio of portfolios) {
+    for (const lob of lobs) {
+      const devs = devMap[`${portfolio}-${lob}`];
+      for (const accidentYear of accidentYears) {
+        for (const dev of devs) {
+          const factor =
+            (portfolios.indexOf(portfolio) + 1) *
+            (lobs.indexOf(lob) + 1) *
+            (accidentYear - 2017);
+          const paid = factor * dev * 10;
+          const incurred = Math.round(paid * 1.2);
+          rows.push({
+            portfolio,
+            lob,
+            accidentYear,
+            dev,
+            paid,
+            incurred,
+          });
+        }
+      }
+    }
+  }
+
+  return rows;
+}
+

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -1,7 +1,13 @@
-import { Link } from 'react-router';
+import { Link, json } from 'react-router';
 import { PageHeader } from 'antd';
 
+import { getTriangles } from '../data/triangles';
+
 export const meta = () => [{ title: 'Triangles' }];
+
+export function loader() {
+  return json({ triangles: getTriangles() });
+}
 
 export default function Triangles() {
   return (


### PR DESCRIPTION
## Summary
- add dummy triangles dataset and TypeScript types
- expose triangles via loader on triangles route

## Testing
- `npm test -- --run` (fails: No test files found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab865016208330ad44e92097303f77