### PR TITLE
Add route tests with vitest setup

### DIFF
--- a/app/routes/__tests__/about.test.tsx
+++ b/app/routes/__tests__/about.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import AboutPage from '../_layout.about';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode, ComponentType } from 'react';
+
+vi.mock('react-router', () => ({
+  MemoryRouter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  UNSAFE_withComponentProps: <T extends ComponentType>(Comp: T) => Comp,
+}));
+
+import { MemoryRouter } from 'react-router';
+
+describe('About', () => {
+  it('renders About page header', () => {
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('heading', { name: /About/i })).toBeInTheDocument();
+  });
+});

--- a/app/routes/__tests__/dashboard.test.tsx
+++ b/app/routes/__tests__/dashboard.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import DashboardPage from '../_layout._index';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode, ComponentType } from 'react';
+
+vi.mock('react-router', () => ({
+  MemoryRouter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  UNSAFE_withComponentProps: <T extends ComponentType>(Comp: T) => Comp,
+}));
+
+import { MemoryRouter } from 'react-router';
+
+describe('Dashboard', () => {
+  it('renders Dashboard page title', () => {
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Dashboard/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/routes/__tests__/triangles.test.tsx
+++ b/app/routes/__tests__/triangles.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode, ComponentType } from 'react';
+
+vi.mock('react-router', () => ({
+  MemoryRouter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  UNSAFE_withComponentProps: <T extends ComponentType>(Comp: T) => Comp,
+  useLoaderData: () => ({
+    triangles: [
+      {
+        portfolio: 'Alpha',
+        lob: 'D&O',
+        accidentYear: 2020,
+        dev: 12,
+        paid: 1000,
+        incurred: 1200,
+      },
+    ],
+  }),
+}));
+
+import { MemoryRouter } from 'react-router';
+import TrianglesPage from '../_layout.triangles';
+
+describe('Triangles', () => {
+  it('renders Triangles page header', () => {
+    render(
+      <MemoryRouter>
+        <TrianglesPage />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Triangles/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+
+const globalObj = globalThis as Record<string, unknown>;
+globalObj.__reactRouter = {};
+globalObj.__vite_plugin_react_preamble_installed__ = true;
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+Object.defineProperty(window, 'getComputedStyle', {
+  writable: true,
+  value: () => ({
+    getPropertyValue: () => '',
+  }),
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,9 @@ import tailwind from '@tailwindcss/vite'; // keep only if you’re using Tailwin
 
 export default defineConfig({
   plugins: [reactRouter(), tsconfigPaths(), tailwind()],
-  test: { environment: 'jsdom' },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./test/setup.ts'],
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom environment and setup file
- add jest-dom setup and globals for tests
- add tests for Dashboard, About, and Triangles routes

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68ab92b703308330aa59c8d60efe36d6