### PR TITLE
Add FastAPI backend scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,8 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm test
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r backend/requirements.txt
+      - run: python -m py_compile backend/app/main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,38 @@
 # --- deps (dev) ---
-FROM node:20-alpine AS dev-deps
+FROM node:20-bullseye AS dev-deps
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --ignore-scripts
 
 # --- deps (prod) ---
-FROM node:20-alpine AS prod-deps
+FROM node:20-bullseye AS prod-deps
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev --ignore-scripts
 
 # --- build ---
-FROM node:20-alpine AS build
+FROM node:20-bullseye AS build
 WORKDIR /app
 COPY . .
 COPY --from=dev-deps /app/node_modules ./node_modules
 RUN npm run build
 
 # --- runtime ---
-FROM node:20-alpine
+FROM node:20-bullseye
 ENV NODE_ENV=production
 ENV PORT=3000
 WORKDIR /app
+# install python and backend dependencies
+RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/apt/lists/*
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN pip3 install --no-cache-dir -r backend/requirements.txt
 COPY package*.json ./
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/build ./build
+COPY backend ./backend
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup --system app && adduser --system --ingroup app app
 USER app
 
-EXPOSE 3000
-CMD ["npm", "run", "start"]
+EXPOSE 3000 8000
+CMD ["bash", "-c", "uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 & npm run start"]

--- a/README.md
+++ b/README.md
@@ -2,21 +2,24 @@
 
 ## 1) What this is (high level)
 
-A demo web app built with React Router v7, TypeScript, Vite and Ant Design. Routing is "Remix-style": the file structure under `app/` defines the URL paths via `@react-router/dev/vite`. The project currently exposes three pages:
+A demo web app built with React Router v7, TypeScript, Vite and Ant Design. Routing is "Remix-style": the file structure under `app/` defines the URL paths via `@react-router/dev/vite`. A lightweight FastAPI backend lives under `backend/` to serve triangle calculations. The project currently exposes three pages:
 
 - **Dashboard** – `app/routes/_layout._index.tsx`
 - **Triangles** – `app/routes/_layout.triangles.tsx`
 - **About** – `app/routes/_layout.about.tsx`
 
-The Triangles page pulls dummy loss-triangle data from a loader function. No real back end or database is involved.
+The Triangles page pulls dummy loss-triangle data from a loader function. API endpoints exist for future triangle operations, but the UI still uses the in-memory dummy data.
 
 ## 2) Quick start (Windows/PowerShell friendly)
 
-Prerequisite: **Node 20+**.
+Prerequisites: **Node 20+** and **Python 3.11+**.
 
 ```powershell
-npm ci       # install deps
-npm run dev  # start dev server
+npm ci                       # install frontend deps
+npm run dev                  # start React dev server
+# in another terminal for the API
+pip install -r backend/requirements.txt
+uvicorn backend.app.main:app --reload
 ```
 
 The dev server prints a URL (typically http://localhost:5173). Open it in your browser. Stop the server with `Ctrl+C`.
@@ -27,7 +30,7 @@ To change the port, set `PORT` before starting:
 $env:PORT=3001; npm run dev
 ```
 
-Build and run a production bundle locally:
+Build and run a production bundle locally (frontend only):
 
 ```powershell
 npm run build
@@ -50,6 +53,7 @@ npm start
 - **package.json** – scripts and dependencies.
 - **Dockerfile** / **.dockerignore** – container setup.
 - **.github/workflows/ci.yml** – GitHub Actions workflow: install deps, lint, typecheck, build, test.
+- **backend/** – FastAPI app and Python requirements.
 
 ## 4) Scripts
 
@@ -107,14 +111,14 @@ To verify production locally, run `npm run build` then `npm start` and visit `ht
 
 ```bash
 docker build -t reserving-app .
-docker run --rm -p 3001:3000 reserving-app
+docker run --rm -p 3001:3000 -p 8001:8000 reserving-app
 ```
 
-Open http://localhost:3001. Map to another host port if 3000 is taken (`-p 5000:3000`).
+Open http://localhost:3001 for the React app and http://localhost:8001 for the API. Map to other host ports if the defaults are taken.
 
 ## 9) CI
 
-`.github/workflows/ci.yml` runs on pushes and pull requests: checkout → `npm ci --ignore-scripts` → lint → typecheck → build → test.
+`.github/workflows/ci.yml` runs on pushes and pull requests: checkout → `npm ci --ignore-scripts` → lint → typecheck → build → test → `pip install` + Python byte-compile.
 
 ## 10) Common issues & fixes
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, List, Optional
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+import pandas as pd
+
+# optional mlflow import
+try:
+    import mlflow  # noqa: F401
+except Exception:
+    mlflow = None  # type: ignore
+
+# import the user’s class if it exists here; otherwise define a tiny stub
+# from reserving import ReservingAppTriangle
+
+# --- begin lightweight inline version using provided class if present ---
+# NOTE: If the project already has ReservingAppTriangle in Python, replace this with a real import.
+class ReservingAppTriangle:
+    def __init__(self, data: pd.DataFrame, origin="origin", development="development",
+                 value_cols: Optional[List[str]] = None, group_cols: Optional[List[str]] = None,
+                 cumulative: bool = True) -> None:
+        self.df = data
+        self.origin = origin
+        self.development = development
+        self.value_cols = value_cols or [c for c in data.columns if c not in {origin, development} | set(group_cols or [])]
+        self.group_cols = group_cols or []
+        self.cumulative = cumulative
+    def exhibits(self) -> Dict[str, Any]:
+        # placeholder: just echo back meta + first 5 rows
+        return {
+            "value_cols": self.value_cols,
+            "group_cols": self.group_cols,
+            "preview": self.df.head(5).to_dict(orient="records"),
+        }
+# --- end inline stub ---
+
+app = FastAPI(title="Reserving API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.post("/triangle/exhibits")
+def triangle_exhibits(payload: Dict[str, Any]) -> Dict[str, Any]:
+    rows: List[Dict[str, Any]] = payload.get("rows", [])
+    origin = payload.get("origin", "origin")
+    development = payload.get("development", "development")
+    value_cols = payload.get("value_cols")
+    group_cols = payload.get("group_cols")
+    cumulative = bool(payload.get("cumulative", True))
+    df = pd.DataFrame(rows)
+    svc = ReservingAppTriangle(df, origin=origin, development=development,
+                               value_cols=value_cols, group_cols=group_cols,
+                               cumulative=cumulative)
+    return {"ok": True, "exhibits": svc.exhibits()}
+
+@app.post("/triangle/fit")
+def triangle_fit(payload: Dict[str, Any]) -> Dict[str, Any]:
+    # placeholder sync fit endpoint; replace with real chainladder logic later
+    return {"ok": True, "message": "fit not implemented yet"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.4
+uvicorn[standard]==0.30.6
+pandas>=2.0
+chainladder>=0.8.24


### PR DESCRIPTION
## Summary
- add backend requirements with FastAPI, Uvicorn, pandas, chainladder
- scaffold FastAPI app with CORS and triangle endpoints

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68acc4d5f1e48330a3839fb267d9d373