### PR TITLE
feat(api): FastAPI CSV upload + AY sum; Triangles page integration; docs on FE/BE connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 PORT=5173
+VITE_API_BASE_URL=http://localhost:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN npm ci --omit=dev --ignore-scripts
 # --- build ---
 FROM node:20-alpine AS build
 WORKDIR /app
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 COPY . .
 COPY --from=dev-deps /app/node_modules ./node_modules
 RUN npm run build
@@ -21,6 +23,8 @@ RUN npm run build
 FROM node:20-alpine
 ENV NODE_ENV=production
 ENV PORT=3000
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 WORKDIR /app
 COPY package*.json ./
 COPY --from=prod-deps /app/node_modules ./node_modules

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Open http://localhost:3001. Map to another host port if 3000 is taken (`-p 5000:
    - `paid`
    - (other columns are ignored)
 5. **Troubleshooting**
-   - CORS errors: ensure the backend allows `http://localhost:5173`.
+   - CORS errors: ensure the backend allows your frontend origin (e.g., `http://localhost:5173` for `npm run dev`, `http://localhost:3000` for `npm start`, or `http://localhost:3001` via Docker).
    - Missing columns: check CSV headers match `accidentYear`/`paid`.
    - Port already in use: choose another port and update `.env`.
 

--- a/README.md
+++ b/README.md
@@ -169,3 +169,17 @@ Open http://localhost:3001. Map to another host port if 3000 is taken (`-p 5000:
    - CORS errors: ensure the backend allows `http://localhost:5173`.
    - Missing columns: check CSV headers match `accidentYear`/`paid`.
    - Port already in use: choose another port and update `.env`.
+
+## Docker only
+
+To run both frontend and backend via Docker Compose:
+
+```powershell
+docker compose up --build
+```
+
+- Frontend: http://localhost:3001
+- Backend: http://localhost:8000
+- Inside Docker, the frontend talks to the backend through `VITE_API_BASE_URL=http://backend:8000`.
+- For local development without Docker, use the "Quick start" and "Backend (FastAPI) & Frontend Connection" steps above.
+

--- a/README.md
+++ b/README.md
@@ -141,3 +141,31 @@ Open http://localhost:3001. Map to another host port if 3000 is taken (`-p 5000:
 - **Husky:** git hooks manager for formatting/linting before commits.
 - **Vitest:** test runner similar to Jest.
 - **AntD:** Ant Design, a React UI component library.
+
+## Backend (FastAPI) & Frontend Connection
+
+1. **Start the backend on port 8000**
+   ```powershell
+   cd backend
+   python -m venv .venv
+   .venv\Scripts\activate
+   pip install -r requirements.txt
+   uvicorn app.main:app --reload --port 8000
+   ```
+2. **Enable the backend in the front end**
+   ```powershell
+   copy .env.example .env
+   ```
+   Edit `.env` if the backend runs on a different port.
+3. **What the upload does**
+   - Triangles page uploads a CSV as `multipart/form-data`.
+   - Request hits `POST /summary/ay-sum`.
+   - Response is JSON with `accidentYear` and summed `paid` values.
+4. **Expected CSV columns**
+   - `accidentYear`
+   - `paid`
+   - (other columns are ignored)
+5. **Troubleshooting**
+   - CORS errors: ensure the backend allows `http://localhost:5173`.
+   - Missing columns: check CSV headers match `accidentYear`/`paid`.
+   - Port already in use: choose another port and update `.env`.

--- a/README.md
+++ b/README.md
@@ -181,5 +181,7 @@ docker compose up --build
 - Frontend: http://localhost:3001
 - Backend: http://localhost:8000
 - Inside Docker, the frontend talks to the backend through `VITE_API_BASE_URL=http://backend:8000`.
+- `VITE_API_BASE_URL` is baked into the frontend at build time via Compose build args.
+- If you change the backend address, rerun `docker compose up --build`.
 - For local development without Docker, use the "Quick start" and "Backend (FastAPI) & Frontend Connection" steps above.
 

--- a/README.md
+++ b/README.md
@@ -184,4 +184,3 @@ docker compose up --build
 - `VITE_API_BASE_URL` is baked into the frontend at build time via Compose build args.
 - If you change the backend address, rerun `docker compose up --build`.
 - For local development without Docker, use the "Quick start" and "Backend (FastAPI) & Frontend Connection" steps above.
-

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -9,8 +9,13 @@ import PageHeader from '../components/PageHeader';
 import type { TriangleRow } from '../data/triangles';
 import { getTriangles } from '../data/triangles';
 
-const API = (import.meta as { env?: { VITE_API_BASE_URL?: string } }).env?.
-  VITE_API_BASE_URL;
+// --- API base: baked env (Vite) with a safe runtime fallback for browsers ---
+const baked = import.meta.env.VITE_API_BASE_URL;
+const runtimeGuess =
+  typeof window !== 'undefined'
+    ? `${window.location.protocol}//${window.location.hostname}:8000`
+    : undefined;
+const API = baked ?? runtimeGuess;
 
 export const meta = () => [{ title: 'Triangles' }];
 
@@ -20,8 +25,12 @@ export function loader() {
 
 export default function Triangles() {
   const { triangles } = useLoaderData<typeof loader>();
-  const [sortedInfo, setSortedInfo] = React.useState<SorterResult<TriangleRow>>({});
-  const [aySum, setAySum] = React.useState<Array<{ accidentYear: number | string; sum: number }>>([]);
+  const [sortedInfo, setSortedInfo] = React.useState<SorterResult<TriangleRow>>(
+    {},
+  );
+  const [aySum, setAySum] = React.useState<
+    Array<{ accidentYear: number | string; sum: number }>
+  >([]);
   const [uploading, setUploading] = React.useState(false);
 
   const handleChange: TableProps<TriangleRow>['onChange'] = (_, __, sorter) => {
@@ -31,7 +40,12 @@ export default function Triangles() {
   };
 
   const dataToExport: TriangleRow[] = React.useMemo(() => {
-    if (sortedInfo && !Array.isArray(sortedInfo) && sortedInfo.order && sortedInfo.field) {
+    if (
+      sortedInfo &&
+      !Array.isArray(sortedInfo) &&
+      sortedInfo.order &&
+      sortedInfo.field
+    ) {
       const field = sortedInfo.field as keyof TriangleRow;
       const sorted = [...triangles].sort((a, b) => {
         const aVal = a[field] as number;
@@ -44,9 +58,16 @@ export default function Triangles() {
   }, [triangles, sortedInfo]);
 
   const handleExport = () => {
-    const headers = ['Portfolio','LOB','AY','Dev (m)','Paid','Incurred'];
-    const rows = dataToExport.map(r => [r.portfolio, r.lob, r.accidentYear, r.dev, r.paid, r.incurred]);
-    const csv = [headers, ...rows].map(r => r.join(',')).join('\n');
+    const headers = ['Portfolio', 'LOB', 'AY', 'Dev (m)', 'Paid', 'Incurred'];
+    const rows = dataToExport.map((r) => [
+      r.portfolio,
+      r.lob,
+      r.accidentYear,
+      r.dev,
+      r.paid,
+      r.incurred,
+    ]);
+    const csv = [headers, ...rows].map((r) => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -57,28 +78,56 @@ export default function Triangles() {
   };
 
   const columns: ColumnsType<TriangleRow> = [
-    { title: 'Portfolio', dataIndex: 'portfolio', key: 'portfolio', width: 120 },
+    {
+      title: 'Portfolio',
+      dataIndex: 'portfolio',
+      key: 'portfolio',
+      width: 120,
+    },
     { title: 'LOB', dataIndex: 'lob', key: 'lob', width: 120 },
     {
-      title: 'AY', dataIndex: 'accidentYear', key: 'accidentYear', width: 90,
+      title: 'AY',
+      dataIndex: 'accidentYear',
+      key: 'accidentYear',
+      width: 90,
       sorter: (a, b) => a.accidentYear - b.accidentYear,
-      sortOrder: !Array.isArray(sortedInfo) && sortedInfo.field === 'accidentYear' ? sortedInfo.order : null,
+      sortOrder:
+        !Array.isArray(sortedInfo) && sortedInfo.field === 'accidentYear'
+          ? sortedInfo.order
+          : null,
     },
     {
-      title: 'Dev (m)', dataIndex: 'dev', key: 'dev', width: 90,
+      title: 'Dev (m)',
+      dataIndex: 'dev',
+      key: 'dev',
+      width: 90,
       sorter: (a, b) => a.dev - b.dev,
-      sortOrder: !Array.isArray(sortedInfo) && sortedInfo.field === 'dev' ? sortedInfo.order : null,
+      sortOrder:
+        !Array.isArray(sortedInfo) && sortedInfo.field === 'dev'
+          ? sortedInfo.order
+          : null,
     },
-    { title: 'Paid', dataIndex: 'paid', key: 'paid', width: 120, render: (v: number) => v.toLocaleString() },
-    { title: 'Incurred', dataIndex: 'incurred', key: 'incurred', width: 120, render: (v: number) => v.toLocaleString() },
+    {
+      title: 'Paid',
+      dataIndex: 'paid',
+      key: 'paid',
+      width: 120,
+      render: (v: number) => v.toLocaleString(),
+    },
+    {
+      title: 'Incurred',
+      dataIndex: 'incurred',
+      key: 'incurred',
+      width: 120,
+      render: (v: number) => v.toLocaleString(),
+    },
   ];
-
-  // ---- Upload to FastAPI: multipart/form-data with CSV ----
-  const beforeUpload = () => false; // prevent auto upload by AntD
 
   const onUpload = async (file: File) => {
     if (!API) {
-      message.error('Backend not configured. Set VITE_API_BASE_URL in .env to use the API.');
+      message.error(
+        'Backend not configured. Set VITE_API_BASE_URL or run backend on :8000.',
+      );
       return;
     }
     setUploading(true);
@@ -108,8 +157,17 @@ export default function Triangles() {
     <div style={{ padding: 16 }}>
       <PageHeader
         title="Triangles"
-        breadcrumb={{ items: [{ title: <Link to="/">Dashboard</Link> }, { title: 'Triangles' }] }}
-        extra={<Button icon={<DownloadOutlined />} onClick={handleExport}>Export CSV</Button>}
+        breadcrumb={{
+          items: [
+            { title: <Link to="/">Dashboard</Link> },
+            { title: 'Triangles' },
+          ],
+        }}
+        extra={
+          <Button icon={<DownloadOutlined />} onClick={handleExport}>
+            Export CSV
+          </Button>
+        }
       />
 
       <Space direction="vertical" size="large" style={{ width: '100%' }}>
@@ -123,19 +181,31 @@ export default function Triangles() {
           scroll={{ x: 'max-content', y: 600 }}
         />
 
-        <Card title="AY Sum (via FastAPI)" extra={<span>{API ? 'API enabled' : 'API not configured'}</span>}>
+        <Card
+          title="AY Sum (via FastAPI)"
+          extra={<span>{API ? `API: ${API}` : 'API not configured'}</span>}
+        >
           <Upload.Dragger
             multiple={false}
-            beforeUpload={beforeUpload}
-            customRequest={({ file, onSuccess, onError }) => {
-              onUpload(file as File).then(() => onSuccess && onSuccess({}, new XMLHttpRequest())).catch(onError);
+            // Trigger our upload and prevent AntD from auto-uploading
+            beforeUpload={(file) => {
+              onUpload(file as File);
+              return false; // keep AntD from trying to upload itself
             }}
+            // remove customRequest entirely
+            showUploadList={false} // optional: hide the file chip if you want
             accept=".csv,text/csv"
             disabled={!API || uploading}
           >
-            <p className="ant-upload-drag-icon"><InboxOutlined /></p>
-            <p className="ant-upload-text">Drop a CSV here, or click to select</p>
-            <p className="ant-upload-hint">Must include columns: accidentYear, paid</p>
+            <p className="ant-upload-drag-icon">
+              <InboxOutlined />
+            </p>
+            <p className="ant-upload-text">
+              Drop a CSV here, or click to select
+            </p>
+            <p className="ant-upload-hint">
+              Must include columns: accidentYear, paid
+            </p>
           </Upload.Dragger>
 
           {aySum.length > 0 && (
@@ -146,7 +216,11 @@ export default function Triangles() {
               rowKey={(r) => String(r.accidentYear)}
               columns={[
                 { title: 'Accident Year', dataIndex: 'accidentYear' },
-                { title: 'Sum (paid)', dataIndex: 'sum', render: (v: number) => v.toLocaleString() },
+                {
+                  title: 'Sum (paid)',
+                  dataIndex: 'sum',
+                  render: (v: number) => v.toLocaleString(),
+                },
               ]}
               dataSource={aySum}
             />

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -2,23 +2,27 @@ import React from 'react';
 import { Link, useLoaderData } from 'react-router';
 import type { ColumnsType, TableProps } from 'antd/es/table';
 import type { SorterResult } from 'antd/es/table/interface';
-import { Table, Button } from 'antd';
+import { Table, Button, Upload, Space, message, Card } from 'antd';
+import { InboxOutlined, DownloadOutlined } from '@ant-design/icons';
 import PageHeader from '../components/PageHeader';
 
 import type { TriangleRow } from '../data/triangles';
 import { getTriangles } from '../data/triangles';
 
+const API = (import.meta as { env?: { VITE_API_BASE_URL?: string } }).env?.
+  VITE_API_BASE_URL;
+
 export const meta = () => [{ title: 'Triangles' }];
 
 export function loader() {
-  return { triangles: getTriangles() };
+  return Response.json({ triangles: getTriangles() });
 }
 
 export default function Triangles() {
   const { triangles } = useLoaderData<typeof loader>();
-  const [sortedInfo, setSortedInfo] = React.useState<SorterResult<TriangleRow>>(
-    {},
-  );
+  const [sortedInfo, setSortedInfo] = React.useState<SorterResult<TriangleRow>>({});
+  const [aySum, setAySum] = React.useState<Array<{ accidentYear: number | string; sum: number }>>([]);
+  const [uploading, setUploading] = React.useState(false);
 
   const handleChange: TableProps<TriangleRow>['onChange'] = (_, __, sorter) => {
     if (!Array.isArray(sorter)) {
@@ -26,13 +30,8 @@ export default function Triangles() {
     }
   };
 
-  const dataToExport = React.useMemo(() => {
-    if (
-      sortedInfo &&
-      !Array.isArray(sortedInfo) &&
-      sortedInfo.order &&
-      sortedInfo.field
-    ) {
+  const dataToExport: TriangleRow[] = React.useMemo(() => {
+    if (sortedInfo && !Array.isArray(sortedInfo) && sortedInfo.order && sortedInfo.field) {
       const field = sortedInfo.field as keyof TriangleRow;
       const sorted = [...triangles].sort((a, b) => {
         const aVal = a[field] as number;
@@ -45,16 +44,9 @@ export default function Triangles() {
   }, [triangles, sortedInfo]);
 
   const handleExport = () => {
-    const headers = ['Portfolio', 'LOB', 'AY', 'Dev (m)', 'Paid', 'Incurred'];
-    const rows = dataToExport.map((r) => [
-      r.portfolio,
-      r.lob,
-      r.accidentYear,
-      r.dev,
-      r.paid,
-      r.incurred,
-    ]);
-    const csv = [headers, ...rows].map((r) => r.join(',')).join('\n');
+    const headers = ['Portfolio','LOB','AY','Dev (m)','Paid','Incurred'];
+    const rows = dataToExport.map(r => [r.portfolio, r.lob, r.accidentYear, r.dev, r.paid, r.incurred]);
+    const csv = [headers, ...rows].map(r => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -65,78 +57,102 @@ export default function Triangles() {
   };
 
   const columns: ColumnsType<TriangleRow> = [
+    { title: 'Portfolio', dataIndex: 'portfolio', key: 'portfolio', width: 120 },
+    { title: 'LOB', dataIndex: 'lob', key: 'lob', width: 120 },
     {
-      title: 'Portfolio',
-      dataIndex: 'portfolio',
-      key: 'portfolio',
-      width: 120,
-    },
-    {
-      title: 'LOB',
-      dataIndex: 'lob',
-      key: 'lob',
-      width: 120,
-    },
-    {
-      title: 'AY',
-      dataIndex: 'accidentYear',
-      key: 'accidentYear',
-      width: 90,
+      title: 'AY', dataIndex: 'accidentYear', key: 'accidentYear', width: 90,
       sorter: (a, b) => a.accidentYear - b.accidentYear,
-      sortOrder:
-        !Array.isArray(sortedInfo) && sortedInfo.field === 'accidentYear'
-          ? sortedInfo.order
-          : null,
+      sortOrder: !Array.isArray(sortedInfo) && sortedInfo.field === 'accidentYear' ? sortedInfo.order : null,
     },
     {
-      title: 'Dev (m)',
-      dataIndex: 'dev',
-      key: 'dev',
-      width: 90,
+      title: 'Dev (m)', dataIndex: 'dev', key: 'dev', width: 90,
       sorter: (a, b) => a.dev - b.dev,
-      sortOrder:
-        !Array.isArray(sortedInfo) && sortedInfo.field === 'dev'
-          ? sortedInfo.order
-          : null,
+      sortOrder: !Array.isArray(sortedInfo) && sortedInfo.field === 'dev' ? sortedInfo.order : null,
     },
-    {
-      title: 'Paid',
-      dataIndex: 'paid',
-      key: 'paid',
-      width: 120,
-      render: (value: number) => value.toLocaleString(),
-    },
-    {
-      title: 'Incurred',
-      dataIndex: 'incurred',
-      key: 'incurred',
-      width: 120,
-      render: (value: number) => value.toLocaleString(),
-    },
+    { title: 'Paid', dataIndex: 'paid', key: 'paid', width: 120, render: (v: number) => v.toLocaleString() },
+    { title: 'Incurred', dataIndex: 'incurred', key: 'incurred', width: 120, render: (v: number) => v.toLocaleString() },
   ];
 
+  // ---- Upload to FastAPI: multipart/form-data with CSV ----
+  const beforeUpload = () => false; // prevent auto upload by AntD
+
+  const onUpload = async (file: File) => {
+    if (!API) {
+      message.error('Backend not configured. Set VITE_API_BASE_URL in .env to use the API.');
+      return;
+    }
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      form.append('ay_col', 'accidentYear');
+      form.append('value_col', 'paid');
+      const res = await fetch(`${API}/summary/ay-sum`, {
+        method: 'POST',
+        body: form,
+      });
+      if (!res.ok) throw new Error(`Backend error: ${res.status}`);
+      const json = await res.json();
+      if (!json.ok) throw new Error(json.error || 'Unknown backend error');
+      setAySum(json.results || []);
+      message.success('Summary calculated');
+    } catch (e: unknown) {
+      console.error(e);
+      message.error(e instanceof Error ? e.message : 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
   return (
-    <div className="p-4">
+    <div style={{ padding: 16 }}>
       <PageHeader
         title="Triangles"
-        breadcrumb={{
-          items: [
-            { title: <Link to="/">Dashboard</Link> },
-            { title: 'Triangles' },
-          ],
-        }}
-        extra={<Button onClick={handleExport}>Export CSV</Button>}
+        breadcrumb={{ items: [{ title: <Link to="/">Dashboard</Link> }, { title: 'Triangles' }] }}
+        extra={<Button icon={<DownloadOutlined />} onClick={handleExport}>Export CSV</Button>}
       />
-      <Table
-        className="mt-4"
-        columns={columns}
-        dataSource={triangles}
-        onChange={handleChange}
-        rowKey={(r) => `${r.portfolio}-${r.lob}-${r.accidentYear}-${r.dev}`}
-        pagination={{ pageSize: 20 }}
-        sticky
-        scroll={{ x: 'max-content', y: 600 }}
-      />
+
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Table
+          columns={columns}
+          dataSource={triangles}
+          onChange={handleChange}
+          rowKey={(r) => `${r.portfolio}-${r.lob}-${r.accidentYear}-${r.dev}`}
+          pagination={{ pageSize: 20 }}
+          sticky
+          scroll={{ x: 'max-content', y: 600 }}
+        />
+
+        <Card title="AY Sum (via FastAPI)" extra={<span>{API ? 'API enabled' : 'API not configured'}</span>}>
+          <Upload.Dragger
+            multiple={false}
+            beforeUpload={beforeUpload}
+            customRequest={({ file, onSuccess, onError }) => {
+              onUpload(file as File).then(() => onSuccess && onSuccess({}, new XMLHttpRequest())).catch(onError);
+            }}
+            accept=".csv,text/csv"
+            disabled={!API || uploading}
+          >
+            <p className="ant-upload-drag-icon"><InboxOutlined /></p>
+            <p className="ant-upload-text">Drop a CSV here, or click to select</p>
+            <p className="ant-upload-hint">Must include columns: accidentYear, paid</p>
+          </Upload.Dragger>
+
+          {aySum.length > 0 && (
+            <Table
+              style={{ marginTop: 16 }}
+              size="small"
+              pagination={false}
+              rowKey={(r) => String(r.accidentYear)}
+              columns={[
+                { title: 'Accident Year', dataIndex: 'accidentYear' },
+                { title: 'Sum (paid)', dataIndex: 'sum', render: (v: number) => v.toLocaleString() },
+              ]}
+              dataSource={aySum}
+            />
+          )}
+        </Card>
+      </Space>
     </div>
   );
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+COPY app ./app
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,32 @@
+# Reserving API (FastAPI)
+
+## Setup (Windows PowerShell)
+```powershell
+cd backend
+python -m venv .venv
+.venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+```
+
+Visit http://localhost:8000/docs to try the /summary/ay-sum endpoint.
+
+Endpoint: POST /summary/ay-sum
+
+form-data:
+
+file (CSV file)
+
+ay_col (default accidentYear)
+
+value_col (default paid)
+
+response:
+
+{
+  "ok": true,
+  "results": [
+    { "accidentYear": 2019, "sum": 12345.0 },
+    { "accidentYear": 2020, "sum": 67890.0 }
+  ]
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,7 @@
 # Reserving API (FastAPI)
 
 ## Setup (Windows PowerShell)
+
 ```powershell
 cd backend
 python -m venv .venv
@@ -24,9 +25,9 @@ value_col (default paid)
 response:
 
 {
-  "ok": true,
-  "results": [
-    { "accidentYear": 2019, "sum": 12345.0 },
-    { "accidentYear": 2020, "sum": 67890.0 }
-  ]
+"ok": true,
+"results": [
+{ "accidentYear": 2019, "sum": 12345.0 },
+{ "accidentYear": 2020, "sum": 67890.0 }
+]
 }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,8 @@ app.add_middleware(
     allow_origins=[
         "http://localhost:5173",
         "http://127.0.0.1:5173",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
         "http://localhost:3001",
         "http://127.0.0.1:3001",
     ],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,12 @@ app = FastAPI(title="Reserving API", version="0.1.0")
 # Allow local dev front-end (adjust as needed)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=[
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+        "http://localhost:3001",
+        "http://127.0.0.1:3001",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,52 @@
+from typing import Dict, Any
+import io
+import pandas as pd
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(title="Reserving API", version="0.1.0")
+
+# Allow local dev front-end (adjust as needed)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.post("/summary/ay-sum")
+async def ay_sum(
+    file: UploadFile = File(...),
+    ay_col: str = Form("accidentYear"),
+    value_col: str = Form("paid"),
+) -> Dict[str, Any]:
+    """
+    Accept a CSV via multipart/form-data and return sum(value_col) grouped by ay_col.
+    Defaults: ay_col='accidentYear', value_col='paid'
+    """
+    raw = await file.read()
+    try:
+        df = pd.read_csv(io.BytesIO(raw))
+    except Exception as e:
+        return {"ok": False, "error": f"Invalid CSV: {e}"}
+
+    if ay_col not in df.columns:
+        return {"ok": False, "error": f"Column '{ay_col}' not in CSV"}
+    if value_col not in df.columns:
+        return {"ok": False, "error": f"Column '{value_col}' not in CSV"}
+
+    # Clean numeric
+    df[value_col] = pd.to_numeric(df[value_col], errors="coerce").fillna(0)
+
+    grouped = (
+        df.groupby(ay_col, dropna=False)[value_col]
+        .sum()
+        .reset_index()
+        .rename(columns={ay_col: "accidentYear", value_col: "sum"})
+        .sort_values("accidentYear")
+    )
+
+    # jsonify-friendly
+    results = grouped.to_dict(orient="records")
+    return {"ok": True, "results": results}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.4
+uvicorn[standard]==0.30.6
+pandas>=2.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.4
 uvicorn[standard]==0.30.6
 pandas>=2.0
+python-multipart==0.0.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   frontend:
-    build: .
+    build:
+      context: .
+      args:
+        VITE_API_BASE_URL: http://backend:8000
     container_name: reserving-frontend
     environment:
       - NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ services:
     build:
       context: .
       args:
-        VITE_API_BASE_URL: http://backend:8000
+        VITE_API_BASE_URL: 'http://localhost:8000' # <-- change from backend:8000
     container_name: reserving-frontend
     environment:
       - NODE_ENV=production
       - PORT=3000
-      # Pass through if you want FE->BE calls in container:
-      - VITE_API_BASE_URL=http://backend:8000
+    # (Optional) remove this — Vite doesn't read VITE_* at runtime:
+    # - VITE_API_BASE_URL=http://backend:8000
     ports:
-      - "3001:3000"   # host:container
+      - '3000:3000'
     depends_on:
       - backend
 
@@ -22,6 +22,8 @@ services:
     container_name: reserving-backend
     environment:
       - PYTHONUNBUFFERED=1
+      # Optional clarity (CORS allow your browser origin)
+      - ALLOWED_ORIGINS=http://localhost:3000
     ports:
-      - "8000:8000"
+      - '8000:8000'
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  frontend:
+    build: .
+    container_name: reserving-frontend
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      # Pass through if you want FE->BE calls in container:
+      - VITE_API_BASE_URL=http://backend:8000
+    ports:
+      - "3001:3000"   # host:container
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: reserving-backend
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "8000:8000"
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add FastAPI backend with `/summary/ay-sum` endpoint and CORS
- wire Triangles page to upload CSV, call backend, and display AY sums
- document backend setup and .env configuration

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acef573d148330a7c1a1ae636125a7