### PR TITLE
feat(triangles): add development date selector

### DIFF
--- a/app/routes/__tests__/triangles.test.tsx
+++ b/app/routes/__tests__/triangles.test.tsx
@@ -26,6 +26,12 @@ describe('Triangles', () => {
     expect(
       screen.getByRole('heading', { name: /Triangles/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Origin Date/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Development Date/i }),
+    ).toBeInTheDocument();
   });
 
   it('parses arbitrary dataset without enforcing headers', () => {

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -92,6 +92,7 @@ export default function Triangles() {
   const [uploading, setUploading] = React.useState(false);
   const [dateColumns, setDateColumns] = React.useState<string[]>([]);
   const [originColumn, setOriginColumn] = React.useState('');
+  const [developmentColumn, setDevelopmentColumn] = React.useState('');
   const [uploadedFile, setUploadedFile] = React.useState<File | null>(null);
   const { Sider, Content } = Layout;
   const { Title } = Typography;
@@ -121,6 +122,7 @@ export default function Triangles() {
       const dateCols = getDateLikeColumns(parsed);
       setDateColumns(dateCols);
       setOriginColumn(dateCols[0] ?? '');
+      setDevelopmentColumn(dateCols[0] ?? '');
       setUploadedFile(file);
       message.success('Data loaded');
     } catch (e: unknown) {
@@ -233,6 +235,23 @@ export default function Triangles() {
               placeholder="Select origin column"
               value={originColumn || undefined}
               onChange={(v) => setOriginColumn(v)}
+              options={dateColumns.map((c) => ({ value: c, label: c }))}
+              disabled={dateColumns.length === 0}
+            />
+            <Title
+              level={4}
+              id="development-date-heading"
+              style={{ margin: 0, color: '#000' }}
+            >
+              Development Date
+            </Title>
+            <Select
+              id="development-date-select"
+              aria-labelledby="development-date-heading"
+              style={{ width: '100%' }}
+              placeholder="Select development column"
+              value={developmentColumn || undefined}
+              onChange={(v) => setDevelopmentColumn(v)}
               options={dateColumns.map((c) => ({ value: c, label: c }))}
               disabled={dateColumns.length === 0}
             />


### PR DESCRIPTION
## Summary
- add development date dropdown with the same validation as origin date
- test heading renders

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ae5e382f548330bcfe6aa282ee531d