### PR TITLE
Add loss field selector for triangles page

### DIFF
--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -143,7 +143,9 @@ export default function Triangles() {
       setDateColumns(dateCols);
       setOriginColumn(dateCols[0] ?? '');
       setDevelopmentColumn(dateCols[0] ?? '');
-      const numericCols = getNumericColumns(parsed);
+      const numericCols = getNumericColumns(parsed).filter(
+        (c) => !dateCols.includes(c),
+      );
       setNumericColumns(numericCols);
       setLossColumn(numericCols[0] ?? '');
       setUploadedFile(file);


### PR DESCRIPTION
## Summary
- derive numeric columns from CSV upload
- add Loss Field dropdown to triangles sidebar
- compute sums using selected loss column

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ae618ab27c8330aadfd9a673090c05