### PR TITLE
Create chainladder triangle view

### DIFF
--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -245,6 +245,10 @@ export default function Triangles() {
         setTriangleRows(data);
         if (data.length > 0) {
           const headers = Object.keys(data[0]);
+          if (originColumn && headers.includes(originColumn)) {
+            headers.splice(headers.indexOf(originColumn), 1);
+            headers.unshift(originColumn);
+          }
           setTriangleColumns(
             headers.map((h) => ({ title: h, dataIndex: h, key: h })),
           );

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import summary
+from .routers import summary, triangle
 
 app = FastAPI(title="Reserving API", version="0.1.0")
 
@@ -22,3 +22,4 @@ app.add_middleware(
 )
 
 app.include_router(summary.router)
+app.include_router(triangle.router)

--- a/backend/app/routers/triangle.py
+++ b/backend/app/routers/triangle.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict
+import io
+
+import pandas as pd
+import chainladder as cl
+from fastapi import APIRouter, File, Form, UploadFile
+
+router = APIRouter()
+
+
+@router.post("/triangle")
+async def build_triangle(
+    file: UploadFile = File(...),
+    origin_col: str = Form(...),
+    development_col: str = Form(...),
+    value_col: str = Form(...),
+) -> Dict[str, Any]:
+    """Return a chainladder Triangle built from an uploaded CSV."""
+    raw = await file.read()
+    try:
+        df = pd.read_csv(io.BytesIO(raw))
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"ok": False, "error": f"Invalid CSV: {exc}"}
+
+    for col in (origin_col, development_col, value_col):
+        if col not in df.columns:
+            return {"ok": False, "error": f"Column '{col}' not in CSV"}
+
+    df[value_col] = pd.to_numeric(df[value_col], errors="coerce").fillna(0)
+
+    try:
+        triangle = cl.Triangle(
+            data=df[[origin_col, development_col, value_col]],
+            origin=origin_col,
+            development=development_col,
+            columns=value_col,
+            cumulative=True,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"ok": False, "error": str(exc)}
+
+    frame = triangle.to_frame().reset_index().rename(columns={"index": origin_col})
+    return {"ok": True, "triangle": frame.to_dict(orient="records")}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.4
 uvicorn[standard]==0.30.6
 pandas>=2.0
 python-multipart==0.0.9
+chainladder==0.8.24


### PR DESCRIPTION
## Summary
- add backend API to build chainladder triangle from uploaded CSV
- wire triangle tab in UI to display chainladder triangle

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6c7282ec8330bb92c3ee53dccd2b