### PR TITLE
feat: add category dimension for triangles

### DIFF
--- a/backend/app/routers/triangle.py
+++ b/backend/app/routers/triangle.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+from typing import Optional
 import io
 
 import pandas as pd
@@ -14,6 +15,7 @@ async def build_triangle(
     origin_col: str = Form(...),
     development_col: str = Form(...),
     value_col: str = Form(...),
+    category_col: Optional[str] = Form(None),
 ) -> Dict[str, Any]:
     """Return a chainladder Triangle built from an uploaded CSV."""
     raw = await file.read()
@@ -22,22 +24,41 @@ async def build_triangle(
     except Exception as exc:  # pragma: no cover - defensive
         return {"ok": False, "error": f"Invalid CSV: {exc}"}
 
-    for col in (origin_col, development_col, value_col):
+    required_cols = [origin_col, development_col, value_col]
+    if category_col:
+        required_cols.append(category_col)
+    for col in required_cols:
         if col not in df.columns:
             return {"ok": False, "error": f"Column '{col}' not in CSV"}
 
     df[value_col] = pd.to_numeric(df[value_col], errors="coerce").fillna(0)
 
     try:
+        cols = [origin_col, development_col]
+        if category_col:
+            cols.append(category_col)
+        cols.append(value_col)
         triangle = cl.Triangle(
-            data=df[[origin_col, development_col, value_col]],
+            data=df[cols],
             origin=origin_col,
             development=development_col,
             columns=value_col,
+            index=category_col if category_col else None,
             cumulative=True,
         )
     except Exception as exc:  # pragma: no cover - defensive
         return {"ok": False, "error": str(exc)}
-
+    if category_col:
+        triangles: Dict[str, Any] = {}
+        categories = triangle.index[category_col].unique()
+        for cat in categories:
+            frame = (
+                triangle.loc[cat]
+                .to_frame()
+                .reset_index()
+                .rename(columns={"index": origin_col})
+            )
+            triangles[str(cat)] = frame.to_dict(orient="records")
+        return {"ok": True, "triangles": triangles}
     frame = triangle.to_frame().reset_index().rename(columns={"index": origin_col})
-    return {"ok": True, "triangle": frame.to_dict(orient="records")}
+    return {"ok": True, "triangles": {"Total": frame.to_dict(orient="records")}}


### PR DESCRIPTION
## Summary
- allow backend triangle builder to group by optional category field
- support optional category dropdown in triangle page and show multiple slices

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af8396899c83309750a2aa54366424