### PR TITLE
fix: use type-only CsvRow import

### DIFF
--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -15,7 +15,7 @@ import {
 import { UploadOutlined, DownloadOutlined } from '@ant-design/icons';
 import PageHeader from '../components/PageHeader';
 import {
-  CsvRow,
+  type CsvRow,
   parseTrianglesCsv,
   getDateLikeColumns,
   getNumericColumns,


### PR DESCRIPTION
## Summary
- use type-only import for CsvRow to satisfy verbatimModuleSyntax

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf895ab88330a71e41308a417f1c