### PR TITLE
feat: show LDF and CDF tables with averages

### DIFF
--- a/app/components/TriangleDisplay.tsx
+++ b/app/components/TriangleDisplay.tsx
@@ -9,6 +9,10 @@ interface TriangleDisplayProps {
   columns: ColumnsType<CsvRow>;
   /** Optional text appended to each triangle title. */
   titleSuffix?: string;
+  ldfTables?: TriangleMap;
+  ldfColumns?: ColumnsType<CsvRow>;
+  cdfTables?: TriangleMap;
+  cdfColumns?: ColumnsType<CsvRow>;
 }
 
 /**
@@ -21,20 +25,50 @@ export default function TriangleDisplay({
   triangles,
   columns,
   titleSuffix,
+  ldfTables,
+  ldfColumns,
+  cdfTables,
+  cdfColumns,
 }: TriangleDisplayProps) {
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
       {Object.entries(triangles).map(([key, data]) => (
-        <Table
+        <Space
           key={key}
-          title={() => (titleSuffix ? `${key} ${titleSuffix}` : key)}
-          columns={columns}
-          dataSource={data}
-          rowKey={(_, i) => String(i)}
-          pagination={{ pageSize: 20 }}
-          sticky
-          scroll={{ x: 'max-content', y: 600 }}
-        />
+          direction="vertical"
+          size="large"
+          style={{ width: '100%' }}
+        >
+          <Table
+            title={() => (titleSuffix ? `${key} ${titleSuffix}` : key)}
+            columns={columns}
+            dataSource={data}
+            rowKey={(_, i) => String(i)}
+            pagination={{ pageSize: 20 }}
+            sticky
+            scroll={{ x: 'max-content', y: 600 }}
+          />
+          {ldfTables && ldfTables[key] && ldfColumns && (
+            <Table
+              title={() => `${key} LDF`}
+              columns={ldfColumns}
+              dataSource={ldfTables[key]}
+              rowKey={(_, i) => String(i)}
+              size="small"
+              pagination={false}
+            />
+          )}
+          {cdfTables && cdfTables[key] && cdfColumns && (
+            <Table
+              title={() => `${key} CDF`}
+              columns={cdfColumns}
+              dataSource={cdfTables[key]}
+              rowKey={(_, i) => String(i)}
+              size="small"
+              pagination={false}
+            />
+          )}
+        </Space>
       ))}
     </Space>
   );

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -66,6 +66,12 @@ export default function Triangles() {
   >([]);
   const [ldfTriangles, setLdfTriangles] = React.useState<TriangleMap>({});
   const [ldfColumns, setLdfColumns] = React.useState<ColumnsType<CsvRow>>([]);
+  const [ldfTables, setLdfTables] = React.useState<TriangleMap>({});
+  const [ldfTableColumns, setLdfTableColumns] = React.useState<
+    ColumnsType<CsvRow>
+  >([]);
+  const [cdfTables, setCdfTables] = React.useState<TriangleMap>({});
+  const [cdfColumns, setCdfColumns] = React.useState<ColumnsType<CsvRow>>([]);
   const { Sider, Content } = Layout;
   const { Title } = Typography;
 
@@ -182,19 +188,24 @@ export default function Triangles() {
         setTriangleColumns([]);
         setLdfTriangles({});
         setLdfColumns([]);
+        setLdfTables({});
+        setLdfTableColumns([]);
+        setCdfTables({});
+        setCdfColumns([]);
         return;
       }
       try {
-        const { triangles: tri, ldfTriangles: ldf } = await buildTriangles(
-          API,
-          uploadedFile,
-          {
-            originCol: originColumn,
-            developmentCol: developmentColumn,
-            valueCol: lossColumn,
-            categoryCol: categoryColumn || undefined,
-          },
-        );
+        const {
+          triangles: tri,
+          ldfTriangles: ldf,
+          ldfTables: ldfTab,
+          cdfTables: cdfTab,
+        } = await buildTriangles(API, uploadedFile, {
+          originCol: originColumn,
+          developmentCol: developmentColumn,
+          valueCol: lossColumn,
+          categoryCol: categoryColumn || undefined,
+        });
         setTriangles(tri);
         const first = Object.values(tri)[0] ?? [];
         setTriangleColumns(buildColumns(first, originColumn));
@@ -202,12 +213,24 @@ export default function Triangles() {
         setLdfTriangles(ldf);
         const ldfFirst = Object.values(ldf)[0] ?? [];
         setLdfColumns(buildColumns(ldfFirst, originColumn));
+
+        setLdfTables(ldfTab);
+        const ldfTabFirst = Object.values(ldfTab)[0] ?? [];
+        setLdfTableColumns(buildColumns(ldfTabFirst, 'type'));
+
+        setCdfTables(cdfTab);
+        const cdfFirst = Object.values(cdfTab)[0] ?? [];
+        setCdfColumns(buildColumns(cdfFirst, 'type'));
       } catch (err) {
         console.error(err);
         setTriangles({});
         setTriangleColumns([]);
         setLdfTriangles({});
         setLdfColumns([]);
+        setLdfTables({});
+        setLdfTableColumns([]);
+        setCdfTables({});
+        setCdfColumns([]);
       }
     };
     build();
@@ -398,6 +421,10 @@ export default function Triangles() {
                     triangles={ldfTriangles}
                     columns={ldfColumns}
                     titleSuffix="— age_to_age factors"
+                    ldfTables={ldfTables}
+                    ldfColumns={ldfTableColumns}
+                    cdfTables={cdfTables}
+                    cdfColumns={cdfColumns}
                   />
                 ),
               },

--- a/app/utils/triangle.ts
+++ b/app/utils/triangle.ts
@@ -14,6 +14,8 @@ export interface BuildTriangleOptions {
 export interface BuiltTriangles {
   triangles: TriangleMap;
   ldfTriangles: TriangleMap;
+  ldfTables: TriangleMap;
+  cdfTables: TriangleMap;
 }
 
 /**
@@ -42,6 +44,8 @@ export async function buildTriangles(
   return {
     triangles: json.triangles || {},
     ldfTriangles: json.ldf_triangles || {},
+    ldfTables: json.ldf_tables || {},
+    cdfTables: json.cdf_tables || {},
   };
 }
 


### PR DESCRIPTION
## Summary
- compute development model to return LDF and CDF average tables
- display LDF and CDF tables for each age-to-age triangle

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b128e6152083308b0f7b3470688118