### PR TITLE
feat: allow custom cdf selection

### DIFF
--- a/app/components/TriangleDisplay.tsx
+++ b/app/components/TriangleDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, Space } from 'antd';
+import { Table, Space, InputNumber } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import type { CsvRow } from '../utils/csv';
 import type { TriangleMap } from '../utils/triangle';
@@ -13,6 +13,7 @@ interface TriangleDisplayProps {
   ldfColumns?: ColumnsType<CsvRow>;
   cdfTables?: TriangleMap;
   cdfColumns?: ColumnsType<CsvRow>;
+  onCdfChange?: (triKey: string, col: string, value: number) => void;
 }
 
 /**
@@ -29,6 +30,7 @@ export default function TriangleDisplay({
   ldfColumns,
   cdfTables,
   cdfColumns,
+  onCdfChange,
 }: TriangleDisplayProps) {
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
@@ -61,7 +63,30 @@ export default function TriangleDisplay({
           {cdfTables && cdfTables[key] && cdfColumns && (
             <Table
               title={() => `${key} CDF`}
-              columns={cdfColumns}
+              columns={cdfColumns.map((col) =>
+                'dataIndex' in col && col.dataIndex !== 'type'
+                  ? {
+                      ...col,
+                      render: (value: number, record: CsvRow) =>
+                        record.type === 'Selected CDF' ? (
+                          <InputNumber
+                            value={value}
+                            min={0}
+                            step={0.01}
+                            onChange={(v) =>
+                              onCdfChange?.(
+                                key,
+                                String(col.dataIndex),
+                                Number(v),
+                              )
+                            }
+                          />
+                        ) : (
+                          value
+                        ),
+                    }
+                  : col,
+              )}
               dataSource={cdfTables[key]}
               rowKey={(_, i) => String(i)}
               size="small"

--- a/app/routes/_layout.triangles.tsx
+++ b/app/routes/_layout.triangles.tsx
@@ -72,6 +72,20 @@ export default function Triangles() {
   >([]);
   const [cdfTables, setCdfTables] = React.useState<TriangleMap>({});
   const [cdfColumns, setCdfColumns] = React.useState<ColumnsType<CsvRow>>([]);
+  const handleCdfChange = React.useCallback(
+    (triKey: string, col: string, value: number) => {
+      setCdfTables((prev) => {
+        const next = { ...prev };
+        const rows = next[triKey];
+        if (!rows) return prev;
+        next[triKey] = rows.map((r) =>
+          r.type === 'Selected CDF' ? { ...r, [col]: value } : r,
+        );
+        return next;
+      });
+    },
+    [],
+  );
   const { Sider, Content } = Layout;
   const { Title } = Typography;
 
@@ -218,8 +232,15 @@ export default function Triangles() {
         const ldfTabFirst = Object.values(ldfTab)[0] ?? [];
         setLdfTableColumns(buildColumns(ldfTabFirst, 'type'));
 
-        setCdfTables(cdfTab);
-        const cdfFirst = Object.values(cdfTab)[0] ?? [];
+        const cdfWithSelected = Object.fromEntries(
+          Object.entries(cdfTab).map(([k, rows]) => {
+            const vol =
+              rows.find((r: CsvRow) => r.type === 'Volume Weighted') ?? rows[0];
+            return [k, [...rows, { ...vol, type: 'Selected CDF' }]];
+          }),
+        );
+        setCdfTables(cdfWithSelected);
+        const cdfFirst = Object.values(cdfWithSelected)[0] ?? [];
         setCdfColumns(buildColumns(cdfFirst, 'type'));
       } catch (err) {
         console.error(err);
@@ -425,6 +446,7 @@ export default function Triangles() {
                     ldfColumns={ldfTableColumns}
                     cdfTables={cdfTables}
                     cdfColumns={cdfColumns}
+                    onCdfChange={handleCdfChange}
                   />
                 ),
               },


### PR DESCRIPTION
## Summary
- allow editing custom Selected CDF row defaulting to volume-weighted
- add handler to update CDF selection state

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b12e2792f08330bfdbec3b6bdddfbd