### PR TITLE
Add horizontal scroll to LDF and CDF tables

### DIFF
--- a/app/components/TriangleDisplay.tsx
+++ b/app/components/TriangleDisplay.tsx
@@ -58,6 +58,7 @@ export default function TriangleDisplay({
               rowKey={(_, i) => String(i)}
               size="small"
               pagination={false}
+              scroll={{ x: 'max-content' }}
             />
           )}
           {cdfTables && cdfTables[key] && cdfColumns && (
@@ -91,6 +92,7 @@ export default function TriangleDisplay({
               rowKey={(_, i) => String(i)}
               size="small"
               pagination={false}
+              scroll={{ x: 'max-content' }}
             />
           )}
         </Space>


### PR DESCRIPTION
## Summary
- enable horizontal scrolling on loss development factor (LDF) and cumulative development factor (CDF) tables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b20e52e7948330b85e349c0dfa9a45